### PR TITLE
Use more appropriate license icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                                 href="https://github.com/sleepdiary/"
                             >
                                 <v-list-item-icon>
-                                    <v-icon>mdi-github</v-icon>
+                                    <v-icon>mdi-code-tags</v-icon>
                                 </v-list-item-icon>
                                 <v-list-item-content>
                                     <v-list-item-title>Source code</v-list-item-title>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                                 href="https://github.com/sleepdiary/sleepdiary.github.io/blob/main/LICENSE"
                             >
                                 <v-list-item-icon>
-                                    <v-icon>mdi-license</v-icon>
+                                    <v-icon>mdi-copyright</v-icon>
                                 </v-list-item-icon>
                                 <v-list-item-content>
                                     <v-list-item-title>License</v-list-item-title>


### PR DESCRIPTION
* s/mdi-license/mdi-copyright/g
* s/mdi-github/mdi-code-tags/g

These seem to be more widely used by other projects